### PR TITLE
Fix weird hover glitch on speaker/organizer pics

### DIFF
--- a/assets/stylesheets/modules/speaker.sass
+++ b/assets/stylesheets/modules/speaker.sass
@@ -18,6 +18,7 @@
   position: relative
   +transition-duration(.25s)
   +transition-property(opacity)
+  +transform(translateZ(0))
   &:hover
     opacity: .75
 


### PR DESCRIPTION
Fixes weird glitches that sometimes happen with transitions by forcing
the browser to use the GPU for the transitions
